### PR TITLE
added instructions for checking cert expiration

### DIFF
--- a/articles/LetsEncrypt.md
+++ b/articles/LetsEncrypt.md
@@ -103,3 +103,18 @@ just need to re-run:
 and then let us know that you have a new certificate and where we can find it.
 
 
+## Checking expiration date
+
+Forgot when your certificate will expire?
+
+Assuming your files are in the default directories, you can run this command:
+    
+    openssl x509 -enddate -noout -in ~/letsencrypt/www.yourdomain.com/cert.pem
+    
+and if you have multiple domains, you can create a bash script like this:
+
+    echo www.domain1.com expires $(openssl x509 -enddate -noout -in ~/letsencrypt/www.domain1.com/cert.pem)
+    echo www.domain2.com expires $(openssl x509 -enddate -noout -in ~/letsencrypt/www.domain2.com/cert.pem)
+    echo www.domain3.com expires $(openssl x509 -enddate -noout -in ~/letsencrypt/www.domain3.com/cert.pem)
+
+which you can run with `bash check_expirations.sh`


### PR DESCRIPTION
I appended the Let's Encrypt article with a bash command to check a certificate's expiration date (which I discovered by searching through the dehydrated script source code) and instructions to create a shell script for multiple checks.

Using LE on PA has become super-easy, thanks very much for all the hard work!